### PR TITLE
Adding a request method for dynamic calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,35 +71,35 @@ The `asJson()` method will send the data using `json` key in the Guzzle request.
 ```php
 $client = $this->client->make('https://httpbin.org/');
 
-// GET
+// Get request
 $response = $client->to('brotli')->get();
 
-// POST
+// Post request
 $response = $client->to('post')->withBody([
 	'foo' => 'bar'
 ])->asJson()->post();
 
-// PUT
+// Put request
 $response = $client->to('put')->withBody([
 	'foo' => 'bar'
 ])->asJson()->put();
 
-// PATCH
+// Patch request
 $response = $client->to('patch')->withBody([
 	'foo' => 'bar'
 ])->asJson()->patch();
 
-// DELETE
+// Delete request
 $response = $client->to('delete?id=1')->delete();
 
 
-// CUSTOM HEADER
+// Headers are easily added using the withHeaders method
 $response = $client->to('get')->withHeaders([
 	'Authorization' => 'Bearer fooBar'
 ])->asJson()->get();
 
 
-// CUSTOM OPTIONS
+// Custom options can be specified for the Guzzle instance
 $response = $client->to('redirect/5')->withOptions([
 	'allow_redirects' => [
 		'max' => 5,
@@ -109,6 +109,11 @@ $response = $client->to('redirect/5')->withOptions([
 		]
 	]
 ])->get();
+
+// You can also specify the request method as a string
+$response = $client->to('post')->withBody([
+	'foo' => 'bar'
+])->asJson()->request('post');
 ```
 
 # Debugging

--- a/src/Client.php
+++ b/src/Client.php
@@ -205,6 +205,20 @@ class Client implements RequestInterface
     {
         return $this->makeRequest('DELETE');
     }
+    
+    /**
+     * @param string $method
+     * @return ResponseInterface
+     * @throws \InvalidArgumentException
+     */
+    public function request(string $method): ResponseInterface
+    {
+        if (!in_array(strtolower($method), ['get', 'post', 'put', 'patch', 'delete'])) {
+            throw new \InvalidArgumentException('The specified method must be either GET, POST, PUT, PATCH or DELETE');
+        }
+
+        return $this->makeRequest($method);
+    }
 
     /**
      * Sends the request.

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -84,4 +84,11 @@ interface RequestInterface
      * @return ResponseInterface
      */
     public function delete(): ResponseInterface;
+    
+    /**
+     * @param string $method
+     * @return ResponseInterface
+     * @throws \InvalidArgumentException
+     */
+    public function request(string $method): ResponseInterface;
 }

--- a/tests/GuzzleClientTest.php
+++ b/tests/GuzzleClientTest.php
@@ -29,6 +29,33 @@ class GuzzleClientTest extends TestCase
             ],
         ], (array)json_decode($response, true));
     }
+    
+    /** @test */
+    function a_valid_request_is_working()
+    {
+        $response = $this->client->to('anything')->withBody([
+            'foo' => 'bar',
+            'baz' => 'qux'
+        ])->asJson()->request('get')->getBody();
+
+        $this->assertArraySubset([
+            'json' => [
+                'foo' => 'bar',
+                'baz' => 'qux'
+            ],
+        ], (array)json_decode($response, true));
+    }
+
+    /** @test */
+    function an_invalid_request_throws_exception()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->client->to('anything')->withBody([
+            'foo' => 'bar',
+            'baz' => 'qux'
+        ])->asJson()->request('foobar')->getBody();
+    }
 
     /** @test */
     function can_retrieve_the_raw_response_body()


### PR DESCRIPTION
Allows requests to be made dynamically by specifying the request method as a string, rather than using the pre-built methods.
The PR contains tests for the functionality, and the updated readme detailing the use.